### PR TITLE
feat: ao setup, verification, and launch scripts with WSL support

### DIFF
--- a/.claude/skills/setup/SKILL.md
+++ b/.claude/skills/setup/SKILL.md
@@ -73,55 +73,45 @@ If `ao` is not found, ask the user ONE question:
 
 **If no:** Note ao is optional and continue to Phase 2.
 
-**If yes:** Run the full installation autonomously. The user should not need to do anything else.
-
-#### Step 1: Check ao prerequisites
+**If yes:** The project includes a standalone setup script that handles everything automatically:
 
 ```bash
-# Check Node.js 20+
-node --version 2>&1 | grep -E '^v(2[0-9]|[3-9][0-9])' || echo "NEED_NODE"
-
-# Check pnpm
-command -v pnpm 2>&1 || echo "NEED_PNPM"
-
-# Check tmux (Linux/macOS only — skip on Windows)
-command -v tmux 2>&1 || echo "NEED_TMUX"
+./scripts/setup-ao.sh
 ```
 
-Install any missing prerequisites automatically:
+This script:
+- Detects the platform (Git Bash, WSL, Linux, macOS)
+- On Windows/Git Bash, automatically relays into WSL (ao requires tmux which needs Linux)
+- Installs all missing dependencies: tmux, Node.js 20+ (via nvm), pnpm, gh CLI, Claude Code CLI, jq
+- Clones and builds ao from `ComposioHQ/agent-orchestrator`
+- Verifies the installation with `ao doctor`
+- Is idempotent — safe to run multiple times
 
-- **Node.js missing/old:** Tell the user "Node.js 20+ is required for ao" and offer to install via `nvm install 20` (if nvm exists) or direct them to https://nodejs.org. If you cannot install it, skip ao and continue — note it can be installed later.
-- **pnpm missing:** Run `npm install -g pnpm`
-- **tmux missing (Linux/macOS):** Run `sudo apt-get install -y tmux` (Debian/Ubuntu) or `brew install tmux` (macOS). On Windows with WSL, note tmux runs inside WSL.
+#### Platform-specific behavior:
 
-#### Step 2: Clone and build ao
+- **Windows (Git Bash):** The script detects MINGW/MSYS and re-launches itself inside WSL. ao and tmux run inside WSL, accessing the repo at `/mnt/c/...`. The `agent-orchestrator.yaml` path must use WSL format (`/mnt/c/Users/...` not `/c/Users/...`).
+- **Linux/macOS:** The script runs natively. tmux is installed via apt-get or brew.
+- **WSL:** Same as Linux — the script runs directly.
+
+#### Manual install (if the script fails):
 
 ```bash
-# Clone into a predictable location
+# Inside WSL or Linux/macOS:
+sudo apt-get install -y tmux jq       # system packages
+npm install -g pnpm                     # pnpm
+npm install -g @anthropic-ai/claude-code # Claude Code CLI
+
+# Clone and build ao
 AO_DIR="$HOME/.agent-orchestrator"
-if [ -d "$AO_DIR" ]; then
-  echo "ao directory already exists at $AO_DIR — updating..."
-  cd "$AO_DIR" && git pull
-else
-  gh repo clone ComposioHQ/agent-orchestrator "$AO_DIR"
-fi
+gh repo clone ComposioHQ/agent-orchestrator "$AO_DIR"
+cd "$AO_DIR" && pnpm install && pnpm build && npm link -g packages/cli
 
-# Install and build
-cd "$AO_DIR" && pnpm install && pnpm build
-
-# Link CLI globally
-npm link -g packages/cli
+# Verify
+ao --version
+ao doctor
 ```
 
-#### Step 3: Verify installation
-
-```bash
-ao --version 2>&1
-```
-
-If `ao --version` succeeds, report: "ao installed successfully." and continue.
-
-If the build fails, don't block setup. Report the error and tell the user: "ao installation failed — you can retry later by running `cd ~/.agent-orchestrator && pnpm install && pnpm build && npm link -g packages/cli`. The pipeline works without ao." Then continue to Phase 2.
+If the build fails, don't block setup. Report the error and tell the user: "ao installation failed — you can retry later by running `./scripts/setup-ao.sh`. The pipeline works without ao." Then continue to Phase 2.
 
 ---
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -82,10 +82,11 @@ These give agents context about your project. At minimum, fill in PROJECT.md —
 
 ### 5. Set Up Agent Orchestrator
 
-- [ ] Install ao: `git clone https://github.com/ComposioHQ/agent-orchestrator.git && cd agent-orchestrator && bash scripts/setup.sh`
-- [ ] Edit `agent-orchestrator.yaml` — set your project name, repo, and local path
-- [ ] Start ao: `ao start`
-- [ ] Start auto-dispatch: `./scripts/poll-and-spawn.sh my-project &`
+- [ ] Install and configure ao: `./scripts/setup-ao.sh` (detects platform, installs all dependencies)
+- [ ] Edit `agent-orchestrator.yaml` — verify your project name, repo, and local path
+- [ ] Start ao + auto-dispatch: `./scripts/ao-start.sh`
+
+> **Windows users:** ao requires tmux, which runs inside WSL. The `setup-ao.sh` script automatically detects Git Bash and relays setup into WSL. After setup, `ao-start.sh` does the same for launching. All ao operations run transparently inside WSL while your code stays on the Windows filesystem.
 
 ### 6. Set Up CODEOWNERS
 
@@ -116,9 +117,12 @@ chmod +x scripts/collect-metrics.sh
 chmod +x scripts/nightly-cycle.sh
 chmod +x scripts/setup-project-board.sh
 chmod +x scripts/update-project-board.sh
+chmod +x scripts/setup-ao.sh
+chmod +x scripts/verify-ao.sh
+chmod +x scripts/ao-start.sh
 ```
 
-- [ ] All nine scripts are executable
+- [ ] All twelve scripts are executable
 
 ### 10. Push and Verify
 
@@ -155,17 +159,109 @@ Everything else is autonomous.
 
 ---
 
-## Optional: GitHub Project Board
+## REQUIRED: GitHub Project Board & Views
 
-A visual Kanban board that auto-updates as signals flow through the pipeline.
+The project board is your team's **operational command center**. Without it, you have no visibility into what agents are doing, what needs your approval, or what's stuck in rework. Every signal, proposal, and code PR flows through this board.
 
-### 11. Set Up Project Board (Optional)
+### 11. Set Up Project Board
 
-- [ ] Run: `./scripts/setup-project-board.sh "My Project"`
-- [ ] Create a PAT at https://github.com/settings/tokens?type=beta with Projects (read/write) + Contents (read/write)
-- [ ] Store it: `gh secret set PROJECT_TOKEN` (paste token when prompted)
+- [ ] Run: `./scripts/setup-project-board.sh "My Project"` (creates board with Pipeline Stage field)
+- [ ] Add custom fields (run each command):
 
-Without the PAT, the board works for manual tracking — workflows skip board updates gracefully.
+```bash
+# These fields are REQUIRED for the approval queue to work
+gh project field-create PROJECT_NUM --owner YOUR_ORG --name "Review Status" --data-type "SINGLE_SELECT" --single-select-options "Queued,Needs Review,Approved,Changes Requested"
+gh project field-create PROJECT_NUM --owner YOUR_ORG --name "Priority" --data-type "SINGLE_SELECT" --single-select-options "P0 Critical,P1 High,P2 Medium,P3 Low"
+gh project field-create PROJECT_NUM --owner YOUR_ORG --name "Signal Type" --data-type "SINGLE_SELECT" --single-select-options "Bug,Feature,Feedback,Analytics"
+```
+
+Replace `PROJECT_NUM` with your project number (stored in `.github/project-number`) and `YOUR_ORG` with your GitHub org or username.
+
+- [ ] Create `.github/project-owner` containing your org name (e.g., `echo "my-org" > .github/project-owner`)
+
+### 11a. Set Up Project Board Views (MANDATORY)
+
+Open your project board URL and create these 3 views. **Do not skip this** — without the Approval Queue, your team cannot efficiently process pipeline work.
+
+#### View 1: Approval Queue (your team's daily driver)
+
+This is where your team spends 90% of their time. It shows exactly what needs a human decision RIGHT NOW.
+
+1. Click **"+ New view"** at the top of the project board
+2. Select **"Table"** layout
+3. Name it **"Approval Queue"**
+4. Click the **filter icon** (funnel) in the toolbar
+5. Add filter: **Review Status** → **is** → **Needs Review**
+6. Click **"Group by"** → select **Pipeline Stage** (groups items by Discovery, Architecture, Specification, Code)
+7. Click **"Sort"** → select **Priority** → **Ascending** (P0 Critical appears first)
+8. Add visible columns by clicking **"+"** on the header row:
+   - Title
+   - Pipeline Stage
+   - Priority
+   - Assignees
+   - Linked pull requests (click the PR link to go directly to the review)
+9. Remove any columns you don't need (right-click column header → Hide)
+
+**How to use it:** Open this view daily. Each row is a PR waiting for your review. Click the linked PR, review it, approve or request changes. The board updates automatically.
+
+#### View 2: Pipeline Overview (at-a-glance health check)
+
+Shows everything in flight across all stages. Use this to spot bottlenecks.
+
+1. Click **"+ New view"**
+2. Select **"Board"** layout
+3. Name it **"Pipeline Overview"**
+4. Set **"Column field"** to **Pipeline Stage**
+5. No filter — shows all items
+6. Cards should show: Title, Priority, Review Status
+
+**How to use it:** Glance at this weekly or when something feels stuck. If one column has too many items, that's your bottleneck.
+
+#### View 3: Rework Needed (items agents need to fix)
+
+Shows items where you requested changes. Agents pick these up automatically via `ao`, but this view lets you track rework progress.
+
+1. Click **"+ New view"**
+2. Select **"Table"** layout
+3. Name it **"Rework"**
+4. Click the **filter icon**
+5. Add filter: **Review Status** → **is** → **Changes Requested**
+6. Click **"Sort"** → select **Priority** → **Ascending**
+7. Add visible columns: Title, Pipeline Stage, Priority, Assignees, Linked pull requests
+
+**How to use it:** Check this when you want to see if agents have addressed your feedback. Once an agent re-submits, the item moves back to the Approval Queue automatically.
+
+### 11b. Set Up Board Automation Token
+
+For the board to auto-update as agents work, you need a Personal Access Token stored as a repo secret.
+
+- [ ] Go to https://github.com/settings/tokens?type=beta
+- [ ] Click **"Generate new token"**
+- [ ] Name it **"Build-Pipe Project Board"**
+- [ ] Under **"Repository access"**, select your repo
+- [ ] Under **"Permissions"**, enable: **Projects (read/write)** and **Contents (read/write)**
+- [ ] Generate and copy the token
+- [ ] Store it: `gh secret set PROJECT_TOKEN` (paste when prompted)
+
+Without the PAT, workflows skip board updates gracefully — the pipeline still works, but the board won't reflect real-time status.
+
+### Board Field Reference
+
+| Field | Values | Updated By |
+|-------|--------|-----------|
+| **Pipeline Stage** | Signal Received, Discovery, Synthesis, Architecture, Specification, Dispatched, Code, Complete | `pipeline-orchestrate.yml`, `signal-ingestion.yml`, `task-complete.yml` |
+| **Review Status** | Queued (agent working), Needs Review (PR open for human), Approved, Changes Requested | `pipeline-orchestrate.yml`, `pr-review-tracking.yml` |
+| **Priority** | P0 Critical, P1 High, P2 Medium, P3 Low | Set manually or by signal classification |
+| **Signal Type** | Bug, Feature, Feedback, Analytics | `signal-ingestion.yml` (from issue label) |
+
+### Review Status Lifecycle
+
+```
+Agent dispatched → Queued
+Agent opens PR   → Needs Review  ← YOU SEE THIS IN THE APPROVAL QUEUE
+You approve      → Approved      → auto-merges or you merge → next stage triggered
+You deny         → Changes Requested → agent reworks → Needs Review (back in queue)
+```
 
 ---
 

--- a/agent-orchestrator.yaml
+++ b/agent-orchestrator.yaml
@@ -13,6 +13,7 @@
 
 dataDir: ~/.agent-orchestrator
 worktreeDir: ~/.worktrees
+port: 3000
 
 defaults:
   runtime: tmux

--- a/scripts/ao-start.sh
+++ b/scripts/ao-start.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# ao-start.sh — Start Agent Orchestrator and auto-dispatch.
+#
+# Launches ao + poll-and-spawn.sh together. Works from Git Bash (auto-relays
+# to WSL) or directly from WSL.
+#
+# Usage:
+#   ./scripts/ao-start.sh                     # Start ao + auto-dispatch
+#   ./scripts/ao-start.sh --ao-only           # Start ao without auto-dispatch
+#
+# To stop:
+#   pkill -f 'ao start' && pkill -f poll-and-spawn
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+MODE="${1:-full}"
+
+# Detect ao project name from agent-orchestrator.yaml
+AO_PROJECT=$(grep -A1 '^projects:' "$REPO_ROOT/agent-orchestrator.yaml" 2>/dev/null | tail -1 | sed 's/:.*//' | tr -d ' ' || echo "")
+if [ -z "$AO_PROJECT" ]; then
+  echo "ERROR: Could not detect project name from agent-orchestrator.yaml"
+  exit 1
+fi
+
+# ─── Git Bash → WSL relay ────────────────────────────
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*)
+    REPO_WSL=$(echo "$REPO_ROOT" | sed 's|^/\([a-zA-Z]\)/|/mnt/\L\1/|')
+    echo "Detected Git Bash. Launching in WSL..."
+    exec wsl bash -c "cd \"$REPO_WSL\" && bash scripts/ao-start.sh $MODE"
+    ;;
+esac
+
+# ─── Pre-flight ──────────────────────────────────────
+"$REPO_ROOT/scripts/verify-ao.sh" || {
+  echo "Pre-flight failed. Run ./scripts/setup-ao.sh to fix."
+  exit 1
+}
+
+cd "$REPO_ROOT"
+
+# ─── Start ao ────────────────────────────────────────
+echo ""
+echo "Starting ao..."
+ao start &
+AO_PID=$!
+echo "ao running (PID ${AO_PID})"
+
+if [ "$MODE" = "--ao-only" ]; then
+  echo "ao-only mode. Auto-dispatch not started."
+  echo "To stop: kill ${AO_PID}"
+  wait "$AO_PID"
+  exit 0
+fi
+
+# ─── Start poll-and-spawn ────────────────────────────
+echo "Starting auto-dispatch (poll-and-spawn)..."
+"$REPO_ROOT/scripts/poll-and-spawn.sh" "$AO_PROJECT" &
+POLL_PID=$!
+echo "poll-and-spawn running (PID ${POLL_PID})"
+
+echo ""
+echo "ao + auto-dispatch running."
+echo "  ao PID:            ${AO_PID}"
+echo "  poll-and-spawn PID: ${POLL_PID}"
+echo ""
+echo "To stop: pkill -f 'ao start' && pkill -f poll-and-spawn"
+echo ""
+
+# Wait for either process to exit
+wait -n "$AO_PID" "$POLL_PID" 2>/dev/null || true
+echo "A process exited. Cleaning up..."
+kill "$AO_PID" "$POLL_PID" 2>/dev/null || true

--- a/scripts/setup-ao.sh
+++ b/scripts/setup-ao.sh
@@ -1,0 +1,323 @@
+#!/usr/bin/env bash
+# setup-ao.sh — Install and configure Agent Orchestrator (ao) for this project.
+#
+# Detects the current environment and acts accordingly:
+#   - Git Bash (Windows): re-launches itself inside WSL automatically
+#   - WSL: installs tmux, Node.js, pnpm, gh, Claude Code, jq, and ao
+#
+# This script is idempotent — safe to run multiple times.
+#
+# Usage:
+#   ./scripts/setup-ao.sh              # From Git Bash or WSL
+#
+# Requirements:
+#   - Windows: WSL installed (wsl --install if not)
+#   - Internet connection for package installation
+
+set -euo pipefail
+
+# ─── Colors ───────────────────────────────────────────
+if [ -t 1 ]; then
+  RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'
+else
+  RED=''; GREEN=''; YELLOW=''; BLUE=''; NC=''
+fi
+
+log()  { echo -e "[setup-ao] $1"; }
+pass() { echo -e "  ${GREEN}PASS${NC}  $1"; }
+warn() { echo -e "  ${YELLOW}WARN${NC}  $1"; }
+fail() { echo -e "  ${RED}FAIL${NC}  $1"; }
+step() { echo -e "\n${BLUE}── $1 ──${NC}"; }
+
+ERRORS=0
+
+# ─── Platform detection ──────────────────────────────
+detect_platform() {
+  case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) echo "windows-gitbash" ;;
+    Linux)
+      if grep -qi microsoft /proc/version 2>/dev/null; then
+        echo "wsl"
+      else
+        echo "linux"
+      fi ;;
+    Darwin) echo "macos" ;;
+    *) echo "unknown" ;;
+  esac
+}
+
+PLATFORM=$(detect_platform)
+
+# ─── Git Bash → WSL relay ────────────────────────────
+if [ "$PLATFORM" = "windows-gitbash" ]; then
+  log "Detected Git Bash on Windows. Relaying to WSL..."
+
+  # Check WSL is available
+  if ! command -v wsl &>/dev/null; then
+    fail "WSL not found. Install it: wsl --install"
+    exit 1
+  fi
+
+  # Convert current path to WSL format
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+  # MSYS paths like /c/Users/... → /mnt/c/Users/...
+  REPO_WSL=$(echo "$REPO_ROOT" | sed 's|^/\([a-zA-Z]\)/|/mnt/\L\1/|')
+
+  log "Repo path in WSL: ${REPO_WSL}"
+  log "Launching setup inside WSL...\n"
+
+  wsl bash -c "cd \"$REPO_WSL\" && bash scripts/setup-ao.sh"
+  exit $?
+fi
+
+# ─── From here on, we're running inside WSL/Linux/macOS ──
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+step "Step 1: System packages"
+
+# tmux
+if command -v tmux &>/dev/null; then
+  pass "tmux $(tmux -V 2>/dev/null || echo '')"
+else
+  log "Installing tmux..."
+  if command -v apt-get &>/dev/null; then
+    sudo apt-get update -qq && sudo apt-get install -y -qq tmux
+  elif command -v brew &>/dev/null; then
+    brew install tmux
+  else
+    fail "Cannot install tmux — no apt-get or brew found"
+    ERRORS=$((ERRORS + 1))
+  fi
+  if command -v tmux &>/dev/null; then
+    pass "tmux installed: $(tmux -V)"
+  fi
+fi
+
+# jq
+if command -v jq &>/dev/null; then
+  pass "jq $(jq --version 2>/dev/null || echo '')"
+else
+  log "Installing jq..."
+  if command -v apt-get &>/dev/null; then
+    sudo apt-get install -y -qq jq
+  elif command -v brew &>/dev/null; then
+    brew install jq
+  fi
+  if command -v jq &>/dev/null; then
+    pass "jq installed"
+  else
+    fail "Could not install jq"
+    ERRORS=$((ERRORS + 1))
+  fi
+fi
+
+# git
+if command -v git &>/dev/null; then
+  pass "git $(git --version | awk '{print $3}')"
+else
+  fail "git not found"
+  ERRORS=$((ERRORS + 1))
+fi
+
+step "Step 2: Node.js 20+"
+
+install_nvm_and_node() {
+  log "Installing nvm + Node.js 20..."
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+
+  # Load nvm into current shell
+  export NVM_DIR="$HOME/.nvm"
+  # shellcheck disable=SC1091
+  [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+
+  nvm install 20
+  nvm use 20
+  nvm alias default 20
+}
+
+if command -v node &>/dev/null; then
+  NODE_VERSION=$(node --version | sed 's/^v//')
+  NODE_MAJOR=$(echo "$NODE_VERSION" | cut -d. -f1)
+  if [ "$NODE_MAJOR" -ge 20 ]; then
+    pass "Node.js v${NODE_VERSION}"
+  else
+    warn "Node.js v${NODE_VERSION} found but v20+ required"
+    install_nvm_and_node
+  fi
+else
+  install_nvm_and_node
+fi
+
+# Verify node is available now
+if command -v node &>/dev/null; then
+  NODE_MAJOR=$(node --version | sed 's/^v//' | cut -d. -f1)
+  if [ "$NODE_MAJOR" -ge 20 ]; then
+    pass "Node.js $(node --version) ready"
+  else
+    fail "Node.js 20+ required, got $(node --version)"
+    ERRORS=$((ERRORS + 1))
+  fi
+else
+  fail "Node.js not available after install attempt"
+  ERRORS=$((ERRORS + 1))
+fi
+
+step "Step 3: pnpm"
+
+if command -v pnpm &>/dev/null; then
+  pass "pnpm $(pnpm --version)"
+else
+  log "Installing pnpm..."
+  npm install -g pnpm
+  if command -v pnpm &>/dev/null; then
+    pass "pnpm $(pnpm --version) installed"
+  else
+    fail "Could not install pnpm"
+    ERRORS=$((ERRORS + 1))
+  fi
+fi
+
+step "Step 4: GitHub CLI (gh)"
+
+if command -v gh &>/dev/null; then
+  pass "gh $(gh --version | head -1 | awk '{print $3}')"
+else
+  log "Installing gh CLI..."
+  if command -v apt-get &>/dev/null; then
+    # GitHub's official apt repository
+    (type -p wget >/dev/null || sudo apt-get install -y -qq wget) \
+      && sudo mkdir -p -m 755 /etc/apt/keyrings \
+      && wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+      && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+      && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+      && sudo apt-get update -qq \
+      && sudo apt-get install -y -qq gh
+  elif command -v brew &>/dev/null; then
+    brew install gh
+  fi
+
+  if command -v gh &>/dev/null; then
+    pass "gh CLI installed"
+  else
+    fail "Could not install gh CLI"
+    ERRORS=$((ERRORS + 1))
+  fi
+fi
+
+# Check gh auth
+if gh auth status --hostname github.com &>/dev/null 2>&1; then
+  pass "gh authenticated"
+else
+  warn "gh not authenticated. Run: gh auth login"
+  log "  ao needs gh to read issues and create PRs."
+fi
+
+step "Step 5: Claude Code CLI"
+
+if command -v claude &>/dev/null; then
+  pass "Claude Code CLI found"
+else
+  log "Installing Claude Code CLI..."
+  npm install -g @anthropic-ai/claude-code
+  if command -v claude &>/dev/null; then
+    pass "Claude Code CLI installed"
+  else
+    fail "Could not install Claude Code CLI"
+    ERRORS=$((ERRORS + 1))
+  fi
+fi
+
+step "Step 6: Agent Orchestrator (ao)"
+
+AO_DIR="$HOME/.agent-orchestrator"
+
+if command -v ao &>/dev/null; then
+  pass "ao $(ao --version 2>/dev/null || echo 'installed')"
+else
+  log "ao not found. Installing..."
+
+  if [ -d "$AO_DIR" ]; then
+    log "Directory exists at $AO_DIR — updating..."
+    cd "$AO_DIR" && git pull
+  else
+    log "Cloning agent-orchestrator..."
+    if command -v gh &>/dev/null; then
+      gh repo clone ComposioHQ/agent-orchestrator "$AO_DIR"
+    else
+      git clone https://github.com/ComposioHQ/agent-orchestrator.git "$AO_DIR"
+    fi
+  fi
+
+  cd "$AO_DIR"
+  log "Installing dependencies..."
+  pnpm install
+
+  log "Building..."
+  pnpm build
+
+  log "Linking CLI globally..."
+  npm link -g packages/cli 2>/dev/null || pnpm link --global packages/cli 2>/dev/null || {
+    fail "Could not link ao CLI globally. Try: cd $AO_DIR && npm link -g packages/cli"
+    ERRORS=$((ERRORS + 1))
+  }
+
+  cd "$REPO_ROOT"
+
+  if command -v ao &>/dev/null; then
+    pass "ao installed: $(ao --version 2>/dev/null || echo 'ok')"
+  else
+    fail "ao not found after install. Check $AO_DIR"
+    ERRORS=$((ERRORS + 1))
+  fi
+fi
+
+step "Step 7: Configuration"
+
+CONFIG_FILE="$REPO_ROOT/agent-orchestrator.yaml"
+
+if [ -f "$CONFIG_FILE" ]; then
+  pass "agent-orchestrator.yaml exists"
+
+  # Check path format
+  CURRENT_PATH=$(grep 'path:' "$CONFIG_FILE" | head -1 | sed 's/.*path: *//; s/^"//; s/"$//')
+  if echo "$CURRENT_PATH" | grep -q '^/mnt/'; then
+    pass "Path uses WSL format: ${CURRENT_PATH}"
+  elif echo "$CURRENT_PATH" | grep -q '^/[a-zA-Z]/'; then
+    warn "Path uses Git Bash format — should be /mnt/c/... for WSL"
+    log "  Current: ${CURRENT_PATH}"
+    WSL_PATH=$(echo "$CURRENT_PATH" | sed 's|^/\([a-zA-Z]\)/|/mnt/\L\1/|')
+    log "  Suggested: ${WSL_PATH}"
+  else
+    pass "Path: ${CURRENT_PATH}"
+  fi
+else
+  fail "agent-orchestrator.yaml not found at $CONFIG_FILE"
+  ERRORS=$((ERRORS + 1))
+fi
+
+step "Step 8: ao doctor"
+
+if command -v ao &>/dev/null; then
+  cd "$REPO_ROOT"
+  log "Running ao doctor..."
+  ao doctor 2>&1 || true
+fi
+
+# ─── Summary ─────────────────────────────────────────
+echo ""
+if [ "$ERRORS" -eq 0 ]; then
+  log "${GREEN}Setup complete — ao is ready!${NC}"
+  log ""
+  log "Next steps:"
+  log "  1. Authenticate gh if needed:  gh auth login"
+  log "  2. Start ao:                   ao start"
+  log "  3. Start auto-dispatch:        ./scripts/poll-and-spawn.sh <project-name> &"
+  log "  Or use the convenience script: ./scripts/ao-start.sh"
+else
+  log "${RED}Setup completed with ${ERRORS} error(s).${NC} Fix the FAIL items above and re-run."
+fi
+
+exit "$ERRORS"

--- a/scripts/setup-ao.sh
+++ b/scripts/setup-ao.sh
@@ -286,10 +286,12 @@ if [ -f "$CONFIG_FILE" ]; then
   if echo "$CURRENT_PATH" | grep -q '^/mnt/'; then
     pass "Path uses WSL format: ${CURRENT_PATH}"
   elif echo "$CURRENT_PATH" | grep -q '^/[a-zA-Z]/'; then
-    warn "Path uses Git Bash format — should be /mnt/c/... for WSL"
-    log "  Current: ${CURRENT_PATH}"
     WSL_PATH=$(echo "$CURRENT_PATH" | sed 's|^/\([a-zA-Z]\)/|/mnt/\L\1/|')
-    log "  Suggested: ${WSL_PATH}"
+    log "Path uses Git Bash format — converting to WSL format..."
+    log "  Before: ${CURRENT_PATH}"
+    log "  After:  ${WSL_PATH}"
+    sed -i "s|path: .*|path: \"${WSL_PATH}\"|" "$CONFIG_FILE"
+    pass "Path auto-fixed to WSL format: ${WSL_PATH}"
   else
     pass "Path: ${CURRENT_PATH}"
   fi

--- a/scripts/verify-ao.sh
+++ b/scripts/verify-ao.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# verify-ao.sh — Health check for Agent Orchestrator readiness.
+#
+# Run before starting ao to verify all prerequisites are met.
+# Exit 0 if everything looks good, exit 1 if something is broken.
+#
+# Usage:
+#   ./scripts/verify-ao.sh
+#
+# Designed for: manual checks, pre-flight before ao start, monitoring scripts.
+
+set -euo pipefail
+
+if [ -t 1 ]; then
+  RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+else
+  RED=''; GREEN=''; YELLOW=''; NC=''
+fi
+
+pass() { echo -e "  ${GREEN}PASS${NC}  $1"; }
+warn() { echo -e "  ${YELLOW}WARN${NC}  $1"; WARNINGS=$((WARNINGS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC}  $1"; FAILURES=$((FAILURES + 1)); }
+
+FAILURES=0
+WARNINGS=0
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "ao health check"
+echo "───────────────"
+
+# 1. WSL check
+if grep -qi microsoft /proc/version 2>/dev/null; then
+  pass "Running inside WSL"
+elif [ "$(uname -s)" = "Linux" ] || [ "$(uname -s)" = "Darwin" ]; then
+  pass "Running on $(uname -s)"
+else
+  warn "Not running in WSL — tmux runtime requires Linux/WSL"
+fi
+
+# 2. ao CLI
+if command -v ao &>/dev/null; then
+  AO_VER=$(ao --version 2>/dev/null || echo "unknown")
+  pass "ao ${AO_VER}"
+else
+  fail "ao not found — run ./scripts/setup-ao.sh"
+fi
+
+# 3. tmux
+if command -v tmux &>/dev/null; then
+  pass "tmux $(tmux -V 2>/dev/null | awk '{print $2}' || echo '')"
+else
+  fail "tmux not found — required for ao runtime"
+fi
+
+# 4. agent-orchestrator.yaml + path
+CONFIG_FILE="$REPO_ROOT/agent-orchestrator.yaml"
+if [ -f "$CONFIG_FILE" ]; then
+  pass "agent-orchestrator.yaml exists"
+
+  CONFIG_PATH=$(grep 'path:' "$CONFIG_FILE" | head -1 | sed 's/.*path: *//; s/^"//; s/"$//')
+  if [ -d "$CONFIG_PATH" ]; then
+    pass "Config path exists: ${CONFIG_PATH}"
+  else
+    fail "Config path does not exist: ${CONFIG_PATH}"
+  fi
+else
+  fail "agent-orchestrator.yaml not found"
+fi
+
+# 5. Config repo matches git remote
+if [ -f "$CONFIG_FILE" ]; then
+  CONFIG_REPO=$(grep 'repo:' "$CONFIG_FILE" | head -1 | awk '{print $2}')
+  ACTUAL_REMOTE=$(cd "$REPO_ROOT" && git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]||; s|\.git$||' || echo "")
+  if [ -n "$ACTUAL_REMOTE" ] && [ "$CONFIG_REPO" = "$ACTUAL_REMOTE" ]; then
+    pass "Repo matches remote: ${CONFIG_REPO}"
+  elif [ -n "$ACTUAL_REMOTE" ]; then
+    warn "Config repo '${CONFIG_REPO}' differs from remote '${ACTUAL_REMOTE}'"
+  else
+    warn "Could not detect git remote to compare"
+  fi
+fi
+
+# 6. gh auth
+if command -v gh &>/dev/null; then
+  if gh auth status --hostname github.com &>/dev/null 2>&1; then
+    pass "gh authenticated"
+  else
+    fail "gh not authenticated — run: gh auth login"
+  fi
+else
+  fail "gh CLI not found"
+fi
+
+# 7. Claude Code CLI
+if command -v claude &>/dev/null; then
+  pass "Claude Code CLI found"
+else
+  fail "Claude Code CLI not found — run: npm install -g @anthropic-ai/claude-code"
+fi
+
+# Summary
+echo ""
+echo "───────────────"
+if [ "$FAILURES" -eq 0 ] && [ "$WARNINGS" -eq 0 ]; then
+  echo -e "${GREEN}All checks passed.${NC} ao is ready to start."
+elif [ "$FAILURES" -eq 0 ]; then
+  echo -e "${YELLOW}${WARNINGS} warning(s), 0 failures.${NC} ao should work but check warnings."
+else
+  echo -e "${RED}${FAILURES} failure(s), ${WARNINGS} warning(s).${NC} Fix FAIL items before starting ao."
+fi
+
+exit "$FAILURES"


### PR DESCRIPTION
## Summary

### ao setup automation (primary)
- **`scripts/setup-ao.sh`** — Full ao setup script. Detects Git Bash vs WSL, auto-relays into WSL, installs tmux + Node.js (via nvm) + pnpm + gh CLI + Claude Code + jq + ao. Auto-fixes Git Bash path format (`/c/...` → `/mnt/c/...`) in config. Idempotent.
- **`scripts/verify-ao.sh`** — 7-check health check (WSL, ao, tmux, config path, repo match, gh auth, claude CLI). Exit 0/1.
- **`scripts/ao-start.sh`** — Convenience launcher for `ao start` + `poll-and-spawn.sh`. Auto-detects project name from `agent-orchestrator.yaml`. Works from Git Bash (relays to WSL).
- **`agent-orchestrator.yaml`** — Added `port: 3000`
- **`.claude/skills/setup/SKILL.md`** — Updated Phase 1b to use `setup-ao.sh`, fixed install commands, added WSL platform detection

### QUICKSTART.md improvements (secondary)
- Fixed step 5 ao install command (was referencing nonexistent `bash scripts/setup.sh`)
- Added Windows/WSL guidance note
- Updated chmod list with 3 new scripts
- Expanded project board section with detailed view setup instructions (Approval Queue, Pipeline Overview, Rework), board automation token setup, field reference table, and review status lifecycle

## Motivation

ao requires tmux which doesn't exist on Windows natively. Windows users need WSL. The existing setup skill mentioned WSL but provided no actionable guidance or automation. These scripts make ao setup fully automated across platforms.

The QUICKSTART project board section was expanded because the previous version was too sparse — users had no guidance on creating the views that make the board useful as a daily command center.

## Test plan
- [ ] Run `./scripts/setup-ao.sh` from Git Bash on Windows — should detect WSL, install deps, auto-fix path
- [ ] Run `./scripts/setup-ao.sh` from WSL directly — should install deps natively
- [ ] Run `./scripts/verify-ao.sh` — should report PASS/FAIL for all 7 checks
- [ ] Run `./scripts/ao-start.sh` — should start ao + poll-and-spawn
- [ ] Run `/setup` skill — Phase 1b should reference `setup-ao.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)